### PR TITLE
Use math.div instead of normal division

### DIFF
--- a/resources/scss/ceres/_variables.scss
+++ b/resources/scss/ceres/_variables.scss
@@ -131,7 +131,7 @@ $list-inline-padding:       5px !default;
 //
 // Define common padding and border radius sizes and more.
 
-$line-height-lg:            (4 / 3) !default;
+$line-height-lg:            math.div(4 / 3) !default;
 
 $border-radius:             .1rem !default;
 $border-radius-sm:          .15rem !default;


### PR DESCRIPTION
Using the latest version of sass may return the following deprecation warning:

> DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
> 
> Recommendation: math.div(4, 3)
> 
> More info and automated migrator: https://sass-lang.com/d/slash-div

### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io
